### PR TITLE
Version lock for major components, PersistentKeepalive=25 by default

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,7 +52,7 @@ yes | $SUDO apt-get -o Dpkg::Options::="--force-confold" -fuy autoremove;
 
 check_root "-H"
 
-$SUDO pip3 install ansible &&
+$SUDO pip3 install ansible==2.9 &&
 export DEBIAN_FRONTEND=
 
 check_root

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,7 +52,7 @@ yes | $SUDO apt-get -o Dpkg::Options::="--force-confold" -fuy autoremove;
 
 check_root "-H"
 
-$SUDO pip3 install ansible==2.9 &&
+$SUDO pip3 install ansible~=6.2 &&
 export DEBIAN_FRONTEND=
 
 check_root

--- a/inventory.yml
+++ b/inventory.yml
@@ -68,7 +68,7 @@ all:
         host: "{{ email_smtp_host }}"
         port: "{{ email_smtp_port }}"
         auth: "on"
-        from: "{{ email_login }}"
+        from: "{{ email }}"
         user: "{{ email_login }}"
         password: "{{ email_password }}"
 

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -37,7 +37,7 @@
 - name: Make sure the Authelia container is created and running
   docker_container:
     name: "authelia"
-    image: "authelia/authelia"
+    image: "authelia/authelia:4.36"
     networks:
       - name: wg_network
     pull: yes

--- a/roles/bunkerweb/tasks/main.yml
+++ b/roles/bunkerweb/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Make sure the Bunkerweb container is created and running
   docker_container:
     name: "bunkerweb"
-    image: "bunkerity/bunkerweb"
+    image: "bunkerity/bunkerweb:1.4.2"
     networks:
       - name: wg_network
     pull: yes

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Make sure the Wireguard container is created and running
   docker_container:
     name: "wg-easy"
-    image: "weejewel/wg-easy"
+    image: "weejewel/wg-easy:7"
     pull: yes
     networks:
       - name: wg_network
@@ -17,6 +17,7 @@
       "WG_HOST": "{{ wireguard_host }}"
       "WG_DEFAULT_DNS": "{{ ','.join(dns_nameservers) }}"
       "WG_PORT": "{{ wireguard_port }}"
+      "WG_PERSISTENT_KEEPALIVE": "25"
     ports:
       - "{{ wireguard_port}}:51820/udp"
     volumes:


### PR DESCRIPTION
Locked Ansible to 6.2, Authelia to 4.36, BunkerWeb to 1.4.2 and wg-easy to 7.